### PR TITLE
Fixes to docs about components in the "Actions" and "Data-display" categories

### DIFF
--- a/content/components/avatar-group/index.md
+++ b/content/components/avatar-group/index.md
@@ -13,9 +13,9 @@ menu:
 
 Responsive Avatar group built with the latest Bootstrap 5. Avatar group component displays a number of avatars grouped together in a stack.
 
-## Stacked avatar
+## Stacked avatars
 
-Include multiple avatars in stacked.
+Stack multiple avatars together. Notice the small overlap between avatars in the example below.
 
 {{< example >}}
 <div class="avatar-stack">
@@ -30,7 +30,7 @@ Include multiple avatars in stacked.
 
 ## Border color
 
-The color of the border around the avatar. Any color that the CSS border-color property accepts can be used.
+Customize the color of the border around the avatar. Any color that the CSS border-color property accepts can be used.
 
 {{< example >}}
 
@@ -43,7 +43,9 @@ The color of the border around the avatar. Any color that the CSS border-color p
 </div>
 {{</ example >}}
 
-## Grouped avatar
+## Grouped avatars
+
+Avatars can also be grouped together, rather than stacked. Notice the absence of overlap between avatars in the example below (compared to earlier examples of stacked avatars).
 
 {{< example>}}
 <div class="avatar-group">

--- a/content/components/avatar/index.md
+++ b/content/components/avatar/index.md
@@ -15,7 +15,7 @@ Responsive avatar built with the latest Bootstrap 5. Avatar component is a visua
 
 ## Avatar examples
 
-Add `.avatar` to any `<img>` elements to make it an avatar.
+Add `.avatar` to any `<img>` element to make it an avatar.
 
 {{< example class="d-flex gap-4" >}}
 <img class="avatar" src="/images/avatar/1.jpg" />

--- a/content/components/badge/index.md
+++ b/content/components/badge/index.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Badge
-description: "Badges are used to inform merchants of the status of an object or of an action that’s been taken."
+description: "Badges are used to inform users of the status of an object or of an action that’s been taken."
 toc: true
 group: data-display
 menu:
@@ -10,9 +10,9 @@ menu:
 
 **Bootstrap 5 Badge component**
 
-Responsive badge built with the latest Bootstrap 5. Badge component is a visual indicator for numeric values such as tallies and scores.
+Responsive badge built with the latest Bootstrap 5. The badge component is a visual indicator for values such as tallies and scores.
 
-Badges are usually placed before or after the label of the thing they're quantifying, such as the number of votes for an issue. 
+Badges are usually placed before or after the label of the thing they're quantifying or referencing, such as the number of votes for an issue. 
 
 ## Badge examples
 
@@ -84,7 +84,7 @@ You can also replace the `.badge` class with a few more utilities without a coun
 
 ## Background colors
 
-Set a background-color with contrasting foreground color with our [.text-bg-{color}]({{< docsref "background-color" >}}) helpers. Previously it was required to manually pair your choice of [.text-{color}]({{< docsref "text-color" >}}) and [.bg-{color}]({{< docsref "background-color" >}}) utilities for styling, which you still may use if you prefer.
+Set a background-color with contrasting foreground color with our [.text-bg-{color}]({{< docsref "background-color" >}}) helpers. Previously, it was required to manually pair your choice of [.text-{color}]({{< docsref "text-color" >}}) and [.bg-{color}]({{< docsref "background-color" >}}) utilities for styling, which you still may use if you prefer.
 
 {{< example >}}
 <span class="badge text-bg-primary">Primary</span>

--- a/content/components/button-group/index.md
+++ b/content/components/button-group/index.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Button Group
-description: "Button group component is a grouping of buttons gives users access to frequently performed, related to each other actions."
+description: "Button group component is a grouping of buttons that gives users access to frequently performed, related actions."
 toc: true
 group: actions
 menu:
@@ -10,11 +10,11 @@ menu:
 
 **Bootstrap 5 Button group component**
 
-Responsive button group built with the latest Bootstrap 5. Button group component is a series of buttons together on a single line or stack them in a vertical column.
+Responsive button group built with the latest Bootstrap 5. Button group component is a series of buttons together on a single line or stacked together on a vertical column.
 
 ## Basic button group
 
-Button groups display multiple buttons with spaces between them out evenly. Just wrap a series of buttons with `.btn` in `.btn-group`. 
+Button groups display multiple buttons with evenly distributed spaces between them. Just wrap a series of buttons with `.btn` in `.btn-group`. 
 
 {{< example >}}
 <div class="btn-group" role="group" aria-label="Basic example">
@@ -49,7 +49,7 @@ In addition, groups and toolbars should be given an explicit label, as most assi
 
 <span class="lozenge new fs-sm">New Feature</span>
 
-Add a `.btn-group-narrow` to sets of two or more buttons into a one group. The spacing will be compacted between each of group button without no spacing.
+Add a `.btn-group-narrow` to sets of two or more buttons into a group. The spacing between buttons within the group will be removed.
 
 {{< example >}}
 <div class="btn-group btn-group-narrow" role="group" aria-label="Basic example">
@@ -60,7 +60,7 @@ Add a `.btn-group-narrow` to sets of two or more buttons into a one group. The s
 </div>
 {{</ example >}}
 
-The Segmented buttons have 2 types of segmented buttons: `Single-select` and `Multi-select`.
+There are 2 types of segmented buttons: `Single-select` and `Multi-select`.
 
 ### Single-select
 
@@ -99,7 +99,7 @@ Use a multi-select segmented button with [Checkbox toggle button]({{< docsref "c
 
 ### With outlined styles 
 
-Use `.btn-outline-*` to remove all background images, shows colors only for the border of the element.
+Use `.btn-outline-*` to remove all background images and show colors only for the border of the element.
 
 {{< example class="d-grid justify-content-start gap-4" >}}
 <div class="btn-group btn-group-narrow" role="group" aria-label="Basic example">
@@ -166,7 +166,7 @@ Combine sets of button groups into button toolbars for more complex components.
 </div>
 {{</ example >}}
 
-Feel free to mix input groups with button groups in your toolbars. Similar to the example above, you’ll likely need some utilities though to space things properly.
+Feel free to mix input groups with button groups in your toolbars. Similar to the example above, you’ll likely need some utilities to space things properly.
 
 {{< example class="d-grid gap-3" >}}
 <div class="btn-toolbar" role="toolbar">
@@ -248,7 +248,7 @@ Use the `.btn-{color}` to control the appearance of the button in the button gro
 {{</ example >}}
 
 
-## Vertical stacked group
+## Vertically stacked group
 
 Use the `.btn-group-vertical` to make a set of buttons appear vertically stacked rather than horizontally. 
 
@@ -262,7 +262,7 @@ Use the `.btn-group-vertical` to make a set of buttons appear vertically stacked
 </div>
 {{</ example >}}
 
-You also can nesting the dropdown
+You can also nest dropdown elements inside button groups.
 
 {{< example >}}
 <div class="btn-group-vertical" role="group" aria-label="Vertical button group">

--- a/content/components/button/index.md
+++ b/content/components/button/index.md
@@ -93,12 +93,12 @@ A warning button appears before we request the user to take action, usually in a
 <button type="button" class="btn btn-warning active">Selected</button>
 {{</ example >}}
 
-### Danager button
+### Danger button
 
 The danger button appears as a final confirmation for a destructive action such as deleting. These are found mostly in confirmation modals. Just add `.btn-danger`.
 
 {{< example class="d-flex align-items-start gap-2 flex-wrap" >}}
-<button type="button" class="btn btn-danger">Danager button</button>
+<button type="button" class="btn btn-danger">Danger button</button>
 <button type="button" class="btn btn-danger" disabled>Disabled</button>
 <button type="button" class="btn btn-danger active">Selected</button>
 {{</ example >}}
@@ -140,7 +140,7 @@ Use `.btn-outline-default` for the standard button.
 
 ### More outline buttons
 
-The below outline buttons that used by Bootstrap by add `.btn-outline-*`.
+You can use the below outline buttons provided by Bootstrap by adding `.btn-outline-*`.
 
 {{< example class="d-flex align-items-start gap-2 flex-wrap" >}}
 <button type="button" class="btn btn-outline-primary">Primary</button>
@@ -157,7 +157,7 @@ The below outline buttons that used by Bootstrap by add `.btn-outline-*`.
 
 ### Disabled state
 
-Make buttons look inactive by adding the `disabled` boolean attribute to any `<button>` element. Disabled buttons have `pointer-events: none` applied to, preventing hover and active states from triggering.
+Make buttons look inactive by adding the `disabled` boolean attribute to any `<button>` element. Disabled buttons have `pointer-events: none` applied to them, preventing hover and active states from triggering.
 
 {{< example class="d-flex align-items-start gap-2 flex-wrap" >}}
 <button type="button" class="btn btn-primary" disabled>Disabled button</button>
@@ -325,7 +325,7 @@ If you don’t want the button text to wrap, you can add the [`.text-nowrap`]({{
 
 ## Social buttons
 
-Combining our icons and custom colors you can create social buttons. Combining our icons and custom colors you can create social buttons. 
+Combining our icons and custom colors you can create social buttons.
 
 {{< example >}}
 <a class="btn btn-primary border-0" style="background-color: #3b5998;" href="#" role="button">
@@ -348,7 +348,7 @@ Combining our icons and custom colors you can create social buttons. Combining o
 </a>
 {{</ example >}}
 
-You also can be changed by modifying a local CSS custom property `--bs-btn-bg`,`--bs-btn-hover-bg` and `--bs-btn-active-bg`. 
+You can also change a button's background color by modifying the custom local CSS properties `--bs-btn-bg`,`--bs-btn-hover-bg` and `--bs-btn-active-bg`. 
 See the [Bootstrap button variables](https://getbootstrap.com/docs/5.2/components/buttons/#variables).
 
 {{< example >}}

--- a/content/components/close-button/index.md
+++ b/content/components/close-button/index.md
@@ -10,7 +10,7 @@ menu:
 
 **Bootstrap 5 Close button component**
 
-Close button built with the latest Bootstrap 5. The close button component used for dismissing content like modals and alerts.
+Close button built with the latest Bootstrap 5. The close button component is used for dismissing content like modals and alerts.
 
 ## Close button
 
@@ -22,7 +22,7 @@ Provide an option to dismiss or close a component with `.btn-close`. Default sty
 
 ## Disabled state
 
-To disabled a close buttons by add the `disabled` attribute. We’ve also applied `pointer-events: none` and `user-select: none` to preventing hover and active states from triggering.
+You can disable a close button by adding the `disabled` attribute. We’ve also applied `pointer-events: none` and `user-select: none` to prevent hover and active states from being triggered.
 
 {{< example >}}
 <button type="button" class="btn-close" disabled aria-label="Close"></button>
@@ -38,7 +38,7 @@ Use the `.btn-close-sm` for the smaller close button.
 <button type="button" class="btn-close btn-close-sm" aria-label="Close"></button>
 {{</ example >}}
 
-Or sets CSS variables: `--bs-btn-close-width` and `--bs-btn-close-height` to customize sizes.
+Or set the `--bs-btn-close-width` and `--bs-btn-close-height` CSS variables to desired values for custom sizing.
 
 {{< example >}}
 <button type="button" class="btn-close" aria-label="Close"

--- a/content/components/table/index.md
+++ b/content/components/table/index.md
@@ -16,7 +16,7 @@ Due to the widespread use of `<table>` elements across third-party widgets like 
 
 ## Basic example
 
-Add the base class `.table` to any `<table>`, then extend with our optional modifier classes or custom styles. 
+Add the base class `.table` to any `<table>`, then extend it with our optional modifier classes or with custom styles. 
 
 {{< example >}}
 <table class="table">
@@ -160,7 +160,7 @@ Add the base class `.table` to any `<table>`, then extend with our optional modi
       <th scope="row">Percentage change</th>
       <td>
         <span class="text-danger">
-          <i class="fas fa-caret-down me-1"></i><span>-48.8%%</span>
+          <i class="fas fa-caret-down me-1"></i><span>-48.8%</span>
         </span>
       </td>
       <td>
@@ -548,7 +548,7 @@ Add `.table-sm` to make any `.table` more compact by cutting all cell padding in
 
 ## Group dividers 
 
-Add a thicker border, darker between table groups—`<thead>`, `<tbody>`, and `<tfoot>`—with `.table-group-divider`.
+Add a thicker, darker border between table groups—`<thead>`, `<tbody>`, and `<tfoot>`—with `.table-group-divider`.
 
 {{< example >}}
 <table class="table">
@@ -587,7 +587,7 @@ Add a thicker border, darker between table groups—`<thead>`, `<tbody>`, and `<
 
 ## Vertical alignment
 
-Table cells of `<thead>` are always vertical aligned to the bottom. Table cells in `<tbody>` inherit their alignment from `<table>` and are aligned to the top by default. 
+Table cells in `<thead>` are always vertically aligned to the bottom. Table cells in `<tbody>` inherit their alignment from `<table>` and are aligned to the top by default. 
 
 Use the vertical align classes to re-align where needed.
 
@@ -693,7 +693,7 @@ Border styles, active styles, and table variants are not inherited by nested tab
 
 To prevent _any_ styles from leaking to nested tables, we use the child combinator (`>`) selector in our CSS. Since we need to target all the `td`s and `th`s in the `thead`, `tbody`, and `tfoot`, our selector would look pretty long without it. As such, we use the rather odd looking `.table > :not(caption) > * > *` selector to target all `td`s and `th`s of the `.table`, but none of any potential nested tables.
 
-Note that if you add `<tr>`s as direct children of a table, those `<tr>` will be wrapped in a `<tbody>` by default, thus making our selectors work as intended.
+Note that if you add `<tr>`s as direct children of a table, those `<tr>`s will be wrapped in a `<tbody>` by default, thus making our selectors work as intended.
 
 ## Anatomy 
 
@@ -818,33 +818,33 @@ A `<caption>` functions like a heading for a table. It helps users with screen r
 {{< example >}}
 <table class="table">
     <caption>List of users</caption>
-      <thead>
-        <tr>
-          <th scope="col">#</th>
-          <th scope="col">First</th>
-          <th scope="col">Last</th>
-          <th scope="col">Handle</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row">1</th>
-          <td>Mark</td>
-          <td>Otto</td>
-          <td>@mdo</td>
-        </tr>
-        <tr>
-          <th scope="row">2</th>
-          <td>Jacob</td>
-          <td>Thornton</td>
-          <td>@fat</td>
-        </tr>
-        <tr>
-          <th scope="row">3</th>
-          <td colspan="2">Larry the Bird</td>
-          <td>@twitter</td>
-        </tr>
-      </tbody>
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">First</th>
+        <th scope="col">Last</th>
+        <th scope="col">Handle</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Mark</td>
+        <td>Otto</td>
+        <td>@mdo</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td>Jacob</td>
+        <td>Thornton</td>
+        <td>@fat</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td colspan="2">Larry the Bird</td>
+        <td>@twitter</td>
+      </tr>
+    </tbody>
   </table>
   {{</ example >}}
 
@@ -885,7 +885,7 @@ You can also put the `<caption>` on the top of the table with `.caption-top`.
 
 ## Responsive tables
 
-Responsive tables allow tables to be scrolled horizontally with ease. Make any table responsive across all viewports by wrapping a `.table` with `.table-responsive`. Or, pick a maximum breakpoint with which to have a responsive table up to by using `.table-responsive{-sm|-md|-lg|-xl|-xxl}`.
+Responsive tables allow tables to be scrolled horizontally with ease. Make any table responsive across all viewports by wrapping a `.table` with `.table-responsive`. Or, pick a maximum breakpoint to have a responsive table up to that breakpoint by using `.table-responsive{-sm|-md|-lg|-xl|-xxl}`.
 
 {{< callout warning >}}
 ##### Vertical clipping/truncation


### PR DESCRIPTION
Apply the following fixes to documentation about components in the "Actions" and "Data-display" categories (see affected components below):

- Fix typos
- Fix minor language issues
- Rephrase some sentences for clarity
- Clean minor/cosmetic errors in code examples

Affected components: Button, Button Group, Close Button, Avatar, Avatar Group, Badge, Table